### PR TITLE
Add ability for users to set defaults through env variables

### DIFF
--- a/Resources/trello.php
+++ b/Resources/trello.php
@@ -27,10 +27,10 @@ $trello_token 			= $data[1];
 $trello_board_id 		= $data[2];
 $name 				= (isset($data[3])) ? stripslashes(trim($data[3])) : '';
 $desc 				= (isset($data[4])) ? stripslashes(trim($data[4])) : '';
-$labels 			= (isset($data[5])) ? stripslashes(trim($data[5])) : '';
-$due 				= (isset($data[6])) ? stripslashes(trim($data[6])) : '';
-$list_name			= (isset($data[7])) ? stripslashes(trim($data[7])) : '';
-$position 			= (isset($data[8])) ? stripslashes(trim($data[8])) : 'bottom';
+$labels 			= (isset($data[5])) ? stripslashes(trim($data[5])) : (getenv('trello.label') ?: '');
+$due 				= (isset($data[6])) ? stripslashes(trim($data[6])) : (getenv('trello.due') ?: '');
+$list_name 			= (isset($data[7])) ? stripslashes(trim($data[7])) : (getenv('trello.list_name') ?: '') ;
+$position 			= (isset($data[8])) ? stripslashes(trim($data[8])) : (getenv('trello.position') ?: 'bottom');
 $url 				= "{$trello_api_endpoint}/boards/{$trello_board_id}?lists=open&list_fields=name&fields=name,desc&key={$trello_key}&token={$trello_token}";
 
 $ch 				= curl_init();


### PR DESCRIPTION
Given that some users like myself might want to always create the cards on the same list, or with the same label, or same due date, or same position _by default_, I added the ability for them to set those defaults vie the environment variables `trello.list_name`, `trello.label`, `trello.due` and `trello.position`.

One can conveniently add or edit those environment variables without programming knowledge through the Alfred Workflow editor, clicking on the `[x]` button on the top right (see screenshot below). If those variables are not set, the script will behave exactly as it did before.

[Here](https://github.com/gamell/Trello-Workflow-for-Alfred/releases/tag/1.6.1) you can find the packaged Alfred Workflow with hose variables defined.

<img width="1051" alt="env-variables-1" src="https://user-images.githubusercontent.com/2460215/44072791-96f57f66-9f45-11e8-9dbc-399744c5c34c.png">

<img width="1007" alt="env-variables-2" src="https://user-images.githubusercontent.com/2460215/44072799-9d4107b4-9f45-11e8-9444-4d71f7f8135f.png">